### PR TITLE
add EnsureLowerBound

### DIFF
--- a/token_bucket_test.go
+++ b/token_bucket_test.go
@@ -136,6 +136,15 @@ func TestTokenBucket(t *testing.T) {
 	// Check that our exhaustion duration is unchanged, since we've stayed in
 	// the positive.
 	checkExhausted(initialExhausted + (20+90)*time.Millisecond)
+
+	// Test EnsureLowerBound.
+	tb.Adjust(-30)
+	check(-9)
+	tb.EnsureLowerBound(-1)
+	check(-1)
+	// Lower-bound cannot exceed burst.
+	tb.EnsureLowerBound(125)
+	check(100)
 }
 
 func TestWaitCtx(t *testing.T) {


### PR DESCRIPTION
This can be used to periodically restore the token bucket to a healthier state. Motivated by
https://cockroachlabs.slack.com/archives/C01SRKWGHG8/p1745882070180759?thread_ts=1745881523.172559&cid=C01SRKWGHG8 and various other places in admission control which implement a token bucket (without using this package) and periodically ensure a 0 or small negative value lower-bound.